### PR TITLE
Create GitLab CI Config File

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,14 @@
+image: mcr.microsoft.com/windows/server
+
+Build:
+  tags:
+    - windows
+  script:
+    - dotnet restore
+    - dotnet build -c Release --no-restore
+    - dotnet publish --property:OutputPath=.\publish\
+    - Move-Item -Path .\publish\publish\*.exe -Destination .\
+  artifacts:
+    paths:
+      - .\*.exe
+    expire_in: 90 days


### PR DESCRIPTION
- This configuration allows GitLab CI to build executable file
- Prerequisites:
  - A GitLab Windows runner labelled with `windows` is required