### PR TITLE
Fix GamePathRegex match to case insensitive

### DIFF
--- a/src/AppConfig.cs
+++ b/src/AppConfig.cs
@@ -60,7 +60,7 @@ public static partial class AppConfig {
         return Path.GetFullPath(Path.Combine(matchResult.Value, "..", entryName));
     }
 
-    [GeneratedRegex(@"(?m).:/.+(GenshinImpact_Data|YuanShen_Data)")]
+    [GeneratedRegex(@"(?m).:/.+(GenshinImpact_Data|YuanShen_Data)", RegexOptions.IgnoreCase)]
     private static partial Regex GamePathRegex();
     
 }


### PR DESCRIPTION
修正國際服初次使用時無法從output_log.txt獲取遊戲路徑的bug，經排查是regex大小寫敏感而無法匹配
![image](https://github.com/HolographicHat/YaeAchievement/assets/46448893/f02847fc-4221-4e4a-a62d-ab5df2a06674)
